### PR TITLE
Adds suppressWarnings

### DIFF
--- a/R/wf_request.R
+++ b/R/wf_request.R
@@ -198,7 +198,7 @@ wf_request <- function(
     }
 
     # rename / move file
-    move <- try(file.rename(src, dst))
+    move <- suppressWarnings(try(file.rename(src, dst)))
 
     # check if the move was succesful
     # fails for separate disks/partitions


### PR DESCRIPTION
While 9dd901ed24216308682ba9cf3037bbfae980b8f6 solved the `file.move()` issue, it still throws a (confusing) warning message. This suppresses it. 