### PR TITLE
Changes archetype

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -1,13 +1,10 @@
 # Methods to deal with visualizing / printing
 # request info (NEEDS documentation)
 
-as.list.ecmwfr_archetype <- function(x, ...) {
-  l <- as.list(body(x))[-1]
-}
 
 print.ecmwfr_archetype <- function(x, ...) {
-  components <- as.list(x)
-  is_dynamic <- lapply(components, class) == "call"
+  components <- x()
+  is_dynamic <- names(components) %in% names(formals(x))
   max_char_name <- max(vapply(names(components), nchar, 1))
   texts <- vapply(components, deparse, "a")
   max_char_text <- max(nchar(texts))
@@ -24,13 +21,5 @@ print.ecmwfr_archetype <- function(x, ...) {
         "=",
         rpad(texts[comps], max_char_text), star, "\n")
   }
-  cat("arguments: ")
-  args <- formals(x)
-  for (a in seq_along(args)) {
-    cat(names(args)[a])
-    if (args[[a]] != rlang::expr()) {
-      cat(" =", args[[a]])
-    }
-    if (a != length(args)) cat(", ", sep = "")
-  }
+  cat(" * : dynamic fields")
 }

--- a/R/wf_modify_request.R
+++ b/R/wf_modify_request.R
@@ -34,9 +34,7 @@
 #'                                 area = "73.5/-27/33/46")
 #' print(str(new_request))
 #'}
-
-wf_modify_request <- function(request, ...){
-
+wf_modify_request <- function(request, ...) {
   # check the request statement
   if(missing(request) || !is.list(request)){
     stop("not a request")
@@ -45,19 +43,14 @@ wf_modify_request <- function(request, ...){
   # load dot arguments
   dot_args <- list(...)
 
-  # loop over everything
-  do.call("c",lapply(names(request), function(request_name){
+  # check that every name is in request
+  in_request <- names(dot_args) %in% names(request)
+  if (sum(!in_request) != 0) {
+    stop("replacements not in original request: ",
+         paste0(names(dot_args)[!in_request], collapse = ", "))
+  }
 
-    # get a replacement value if matching
-    # a name in the original request
-    replacement <- dot_args[request_name]
+  request[names(dot_args)] <- dot_args
 
-    # no clue why is.null doesn't work in this case
-    # print might just fill this with NULL
-    if(is.na(names(replacement))) {
-      return(request[request_name])
-    } else {
-      return(replacement)
-    }
-  }))
+  request
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -155,3 +155,16 @@ wf_check_login <- function(user, key, service) {
     return(httr::status_code(ct) == 404)
   }
 }
+
+
+# build an archetype from arguments and body (either list or expression)
+new_archetype <- function(args, body) {
+  if (is.list(body)) {
+    body_exp <- rlang::expr(list())
+    body_exp[names(body)] <- body
+    body <- body_exp
+  }
+  f <- rlang::new_function(args, body)
+  class(f) <- c("ecmwfr_archetype", class(f))
+  f
+}

--- a/man/wf_archetype.Rd
+++ b/man/wf_archetype.Rd
@@ -4,16 +4,16 @@
 \alias{wf_archetype}
 \title{Creates an archetype function}
 \usage{
-wf_archetype(request, ...)
+wf_archetype(request, dynamic_fields)
 }
 \arguments{
-\item{request}{a MARS or CDS request as an R list object, with certain
-parameters modified to take arguments.}
+\item{request}{a MARS or CDS request as an R list object.}
 
-\item{...}{list of arguments for which a default value can be set}
+\item{dynamic_fields}{character vector of fields that could be changed.}
 }
 \value{
-a MARS / CDS request
+a function that takes `dynamic_fields` as arguments and returns a
+request as an R list object.
 }
 \description{
 Creates a universal MARS / CDS formatting function, in ways
@@ -31,20 +31,21 @@ will be guaranteed and tested for.
 \examples{
 \dontrun{
 # format an archetype function
-ERA_interim <- wf_archetype(
- list(class = "ei",
-    dataset = "interim",
-    expver = "1",
-    levtype = "pl",
-    stream = "moda",
-    type = "an",
-    format = "netcdf",
-    date = date,
-    grid = paste0(res, "/", res),
-    levelist = levs,
-    param = "155.128",
-    target = "output"),
-res = 3  # sets default argument
+ERAI <- wf_archetype(
+  request = list(stream = "oper",
+                 levtype = "sfc",
+                 param = "165.128/166.128/167.128",
+                 dataset = "interim",
+                 step = "0",
+                 grid = "0.75/0.75",
+                 time = "00/06/12/18",
+                 date = "2014-07-01/to/2014-07-31",
+                 type = "an",
+                 class = "ei",
+                 area = "73.5/-27/33/45",
+                 format = "netcdf",
+                 target = "tmp.nc"),
+  dynamic_fields = c("date", "time")
 )
 
 # print output of the function with below parameters

--- a/tests/testthat/test_helper_functions.R
+++ b/tests/testthat/test_helper_functions.R
@@ -24,9 +24,9 @@ test_that("modify request tests",{
   ))
 
   expect_error(str(
-      wf_modify_request(date = "2014-07-01/to/2014-08-31",
-                        area = "73.5/-27/33/46")
-    ))
+    wf_modify_request(date = "2014-07-01/to/2014-08-31",
+                      area = "73.5/-27/33/46")
+  ))
 })
 
 test_that("create tests archetype", {
@@ -41,27 +41,27 @@ test_that("create tests archetype", {
       stream = "moda",
       type = "an",
       format = "netcdf",
-      date = date,
-      grid = paste0(res, "/", res),
-      levelist = levs,
+      date = "20140101",
+      grid = "3/3",
+      levelist = "1000",
       param = "155.128",
       target = "output"
-      ),
-    res = 3
-   )
+    ),
+    dynamic_fields = c("date", "grid", "levelist")
+  )
 
   # dump things as a string
-  expect_output(str(ERA_interim("20100101", 3, 200)))
+  expect_output(str(ERA_interim("20100101", "3/3", "200")))
 
   # tests the method to print the archetype nicely
-  expect_output(print(ERA_interim("20100101", 3, 200)))
+  expect_output(print(ERA_interim("20100101", "3/3", "200")))
 
-  # print function call als args and body parameters
-  # in a list, no errors allowed
-  expect_silent(as.list(ERA_interim))
-
+  # missing fields
+  expect_error(str(wf_archetype(request = list(date = "20140101"),
+                                dynamic_fields = "res")
+  ))
   # no request provided
   expect_error(str(
-    wf_archetype(res = 3)
+    wf_archetype(dynamic_fields = "res")
   ))
 })


### PR DESCRIPTION
This implements #21 . So this:

```r
ERAI <- wf_archetype(
  request = list(stream = "oper",
                 levtype = "sfc",
                 param = "165.128/166.128/167.128",
                 dataset = "interim",
                 step = "0",
                 grid = "0.75/0.75",
                 time = "00/06/12/18",
                 date = "2014-07-01/to/2014-07-31",
                 type = "an",
                 class = "ei",
                 area = "73.5/-27/33/45",
                 format = "netcdf",
                 target = "tmp.nc"),
  dynamic_fields = c("date", "time")
)
```

returns a function with `date` and `time` arguments with the defaults taken from the original request. Since the original archetype can be recovered by just evaluating the function, I removed the `as.list.ecmwfr_archetype` method. 