### PR TITLE
Overwrites file if exists

### DIFF
--- a/R/wf_request.R
+++ b/R/wf_request.R
@@ -210,7 +210,7 @@ wf_request <- function(
     # fails for separate disks/partitions
     # then copy and remove
     if(!move){
-      file.copy(src, dst)
+      file.copy(src, dst, overwrite = TRUE)
       file.remove(src)
     }
 


### PR DESCRIPTION
The recent fix of file.rename() uses file.copy(), but the default behaviour is to not overwrite files. This changes that. 