### PR TITLE
wf_set_key returns the user invisibly

### DIFF
--- a/R/wf_set_key.R
+++ b/R/wf_set_key.R
@@ -6,6 +6,8 @@
 #' @param user user (email address) used to sign up for the ECMWF data service
 #' @param key token provided by ECMWF
 #' @param service service associated with credentials ("webapi" or "cds")
+#'
+#' @return It invisibly returns the user.
 #' @keywords key management
 #' @seealso \code{\link[ecmwfr]{wf_get_key}}
 #' @export
@@ -62,5 +64,7 @@ wf_set_key <- function(user, key, service){
                                 username = user,
                                 password = key)
     message("User ", user, " for ", service, " service added successfully")
+    return(invisible(user))
   }
+
 }

--- a/man/wf_set_key.Rd
+++ b/man/wf_set_key.Rd
@@ -13,6 +13,9 @@ wf_set_key(user, key, service)
 
 \item{service}{service associated with credentials ("webapi" or "cds")}
 }
+\value{
+It invisibly returns the user.
+}
 \description{
 Saves the token to your local keychain under
 a service called "ecmwfr".


### PR DESCRIPTION
`wf_set_key()` returns the user invisibly so that you can use 

```r
user <- wf_set_key(service)

request(..., user = user)
```