### PR TITLE
Obfuscates password prompt

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Depends:
 Imports:
     httr,
     keyring,
-    memoise
+    memoise,
+    getPass
 License: AGPL-3
 LazyData: true
 ByteCompile: true

--- a/R/wf_set_key.R
+++ b/R/wf_set_key.R
@@ -49,7 +49,8 @@ wf_set_key <- function(user, key, service){
     browseURL(wf_key_page(service))
     message("Login or register to get a key")
     user <- readline("User ID / email: ")
-    key <- readline("API key: ")
+    key <- getPass::getPass(msg = "API key: ")
+    if (is.null(key)) stop("No key supplied.")
   }
 
   # check login


### PR DESCRIPTION
Right now entering passwords interactively is safe in that it doesn't store it in history, but they are still shown in the console. This uses the [getPass](https://github.com/wrathematics/getPass) package to ask for user input obfuscating the input. (It's the same package used by `keyring::set_key()`.) 

This is how it looks in RStudio:
![image](https://user-images.githubusercontent.com/8617595/57101167-02ba5a80-6cf7-11e9-9b08-967ff9a046db.png)

And this is on a terminal:
![image](https://user-images.githubusercontent.com/8617595/57101196-11a10d00-6cf7-11e9-89e3-f993b2c6921e.png)
