### PR TITLE
Smart username detection

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -131,7 +131,7 @@ ecmwf_running <- function(url){
 }
 
 # builds keychain service name from service
-make_key_service <- function(service) {
+make_key_service <- function(service = "") {
   paste("ecmwfr", service, sep = "_")
 }
 


### PR DESCRIPTION
This addresses #33. If `user` is missing in request, it lists every username in the keyring belonging to the package, checks the request and keeps the one that didn't fail. 