### PR TITLE
Allows to run wf_request as an RStudio job

### DIFF
--- a/R/wf_request.R
+++ b/R/wf_request.R
@@ -75,6 +75,12 @@ wf_request <- function(
     if (!requireNamespace("rstudioapi", quietly = TRUE)) {
       stop("Jobs are only supported in RStudio.")
     }
+
+    if (!rstudioapi::isAvailable("1.2")) {
+      stop("Need at least version 1.2 of RStudio to use jobs. Currently running ",
+           rstudioapi::versionInfo()$version, ".")
+    }
+
     job <- rstudioapi::jobRunScript(path = script, name = job_name, exportEnv = "R_GlobalEnv")
     return(invisible(job))
   }

--- a/R/wf_request.R
+++ b/R/wf_request.R
@@ -65,11 +65,13 @@ wf_request <- function(
 ){
 
   if (!is.null(job_name)) {
-    force(path)
+    # Evaluates all arguments.
     call <- match.call()
     call$path <- path
+    call_list <- lapply(call, eval)
+    call[names(call_list)[-1]] <- call_list[-1]
 
-    script <- make_script(request = request, call = call, name = job_name)
+    script <- make_script(call = call, name = job_name)
     if (!requireNamespace("rstudioapi", quietly = TRUE)) {
       stop("Jobs are only supported in RStudio.")
     }

--- a/R/wf_request.R
+++ b/R/wf_request.R
@@ -60,11 +60,11 @@ wf_request <- function(
   transfer = TRUE,
   path = tempdir(),
   time_out = 3600,
-  job_name = NULL,
+  job_name,
   verbose = TRUE
 ){
 
-  if (!is.null(job_name)) {
+  if (!missing(job_name)) {
     # Evaluates all arguments.
     call <- match.call()
     call$path <- path

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -176,3 +176,16 @@ new_archetype <- function(args, body) {
   class(f) <- c("ecmwfr_archetype", class(f))
   f
 }
+
+
+# Creates a script to then run as a job
+make_script <- function(request, call, name) {
+  script <- tempfile()
+
+  call$request <- dput(request)
+  j <- which(names(call) == "job_name")
+  call[j] <- list(NULL)
+
+  lines <- writeLines(paste0("library(ecmwfr)\n", name, " <- ", paste0(deparse(call), collapse = "")), script)
+  return(script)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -179,10 +179,9 @@ new_archetype <- function(args, body) {
 
 
 # Creates a script to then run as a job
-make_script <- function(request, call, name) {
+make_script <- function(call, name) {
   script <- tempfile()
 
-  call$request <- dput(request)
   j <- which(names(call) == "job_name")
   call[j] <- list(NULL)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -182,8 +182,7 @@ new_archetype <- function(args, body) {
 make_script <- function(call, name) {
   script <- tempfile()
 
-  j <- which(names(call) == "job_name")
-  call[j] <- list(NULL)
+  call$job_name <- NULL
 
   lines <- writeLines(paste0("library(ecmwfr)\n", name, " <- ", paste0(deparse(call), collapse = "")), script)
   return(script)

--- a/man/wf_request.Rd
+++ b/man/wf_request.Rd
@@ -5,7 +5,7 @@
 \title{ECMWF data request and download}
 \usage{
 wf_request(request, user, transfer = TRUE, path = tempdir(),
-  time_out = 3600, verbose = TRUE)
+  time_out = 3600, job_name = NULL, verbose = TRUE)
 }
 \arguments{
 \item{request}{nested list with query parameters following the layout
@@ -20,6 +20,9 @@ used to retrieve the token set by \code{\link[ecmwfr]{wf_set_key}}}
 
 \item{time_out}{how long to wait on a download to start (default =
 \code{3*3600} seconds).}
+
+\item{job_name}{optional name to use as an RStudio job and as output variable
+name}
 
 \item{verbose}{show feedback on processing}
 }
@@ -40,7 +43,7 @@ to identify possible problems.
 # set key
 wf_set_key(user = "test@mail.com", key = "123")
 
-request <-  = list(stream = "oper",
+request <- list(stream = "oper",
    levtype = "sfc",
    param = "167.128",
    dataset = "interim",
@@ -56,6 +59,11 @@ request <-  = list(stream = "oper",
 
 # demo query
 wf_request(request = request, user = "test@mail.com")
+
+# Run as an RStudio Job. When finished, will create a
+# variable named "test" in your environment with the path to
+# the downloaded file.
+wf_request(request = request, user = "test@mail.com", job_name = "test")
 }
 }
 \seealso{

--- a/man/wf_request.Rd
+++ b/man/wf_request.Rd
@@ -5,7 +5,7 @@
 \title{ECMWF data request and download}
 \usage{
 wf_request(request, user, transfer = TRUE, path = tempdir(),
-  time_out = 3600, job_name = NULL, verbose = TRUE)
+  time_out = 3600, job_name, verbose = TRUE)
 }
 \arguments{
 \item{request}{nested list with query parameters following the layout


### PR DESCRIPTION
Let me know what you think about this. It adds a `job_name` that, if not `NULL`, will run `wf_request()` as an asynchronous job in RStudio. 

Working sample:
![Peek 2019-05-17 12-33](https://user-images.githubusercontent.com/8617595/57939619-12ae6e80-78a1-11e9-81dd-a2497798721f.gif)

When done, the path to the downloaded file is added to the global environment with the same name as the job. 

When running from outside RStudio it will throw an error. 

> library(ecmwfr)
> wf_request(request, job_name = "test")
Error: RStudio not running
> 
