### PR TITLE
Checks for file download

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     httr,
     keyring,
     memoise,
-    getPass
+    getPass,
+    curl
 License: AGPL-3
 LazyData: true
 ByteCompile: true

--- a/R/wf_transfer.R
+++ b/R/wf_transfer.R
@@ -62,22 +62,53 @@ wf_transfer <- function(
   # download routine depends on service queried
   if(service == "cds") {
     response <- httr::GET(url,
-      httr::authenticate(user, key),
-      httr::add_headers(
-        "Accept" = "application/json",
-        "Content-Type" = "application/json"),
-      encode = "json"
+                          httr::authenticate(user, key),
+                          httr::add_headers(
+                            "Accept" = "application/json",
+                            "Content-Type" = "application/json"),
+                          encode = "json"
     )
   } else {
-    response <- httr::GET(
-      url,
-      httr::add_headers(
-        "Accept" = "application/json",
-        "Content-Type" = "application/json",
-        "From" = user,
-        "X-ECMWF-KEY" = key),
-      encode = "json"
+    # Webapi
+    response <- retrieve_header(url,
+                                list(
+                                  "Accept" = "application/json",
+                                  "Content-Type" = "application/json",
+                                  "From" = user,
+                                  "X-ECMWF-KEY" = key)
     )
+    status_code <- response[["status_code"]]
+
+    if (httr::http_error(status_code)) {
+      stop("Your requested download failed - check url", call. = FALSE)
+    }
+
+    if (status_code == "202") {  # still processing
+      # Simulated content with the things we need to use.
+      ct <- list(code = status_code,
+                 retry = as.numeric(response$headers$`retry-after`),
+                 href = url)
+      return(invisible(ct))
+
+    } else if (status_code == "200") {  # Done!
+      message("Downloading file")
+      response <- httr::GET(
+        url,
+        httr::add_headers(
+          "Accept" = "application/json",
+          "Content-Type" = "application/json",
+          "From" = user,
+          "X-ECMWF-KEY" = key),
+        encode = "json",
+        httr::write_disk(tmp_file, overwrite = TRUE),   # write on disk!
+        httr::progress()
+      )
+
+      return(invisible(list(code = 302,
+                            href = url)))
+    } else {
+      stop("Your requested download had a problem with code ", status_code, call. = FALSE)
+    }
   }
 
   # trap (http) errors on download, return a general error statement

--- a/R/wf_transfer.R
+++ b/R/wf_transfer.R
@@ -91,7 +91,7 @@ wf_transfer <- function(
       return(invisible(ct))
 
     } else if (status_code == "200") {  # Done!
-      message("Downloading file")
+      message("\nDownloading file")
       response <- httr::GET(
         url,
         httr::add_headers(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -187,3 +187,18 @@ make_script <- function(call, name) {
   lines <- writeLines(paste0("library(ecmwfr)\n", name, " <- ", paste0(deparse(call), collapse = "")), script)
   return(script)
 }
+
+
+# Downlaods only the header information
+retrieve_header <- function(url, headers) {
+  h <- curl::new_handle()
+  curl::handle_setheaders(h, .list = headers)
+  con <- curl::curl(url, handle = h)
+
+  open(con, "rf")
+  head <- curl::handle_data(h)
+  close(con)
+
+  head$headers <- curl::parse_headers_list(head$headers)
+  return(head)
+}


### PR DESCRIPTION
Checks if data is ready without downloading the entire file and only when it is, it downloads directly to disk. (Closes #39)

The result is: 

```r
library(ecmwfr)
request <- list(stream = "oper",
                levtype = "sfc",
                param = "167.128",
                dataset = "interim",
                step = "0",
                grid = "0.75/0.75",
                time = "00",
                date = "2014-07-01/to/2014-07-02",
                type = "an",
                class = "ei",
                area = "50/10/51/11",
                format = "netcdf",
                target = "tmp.nc")

wf_request(request = request)

#> Requesting data to the webapi service with username eliocampitelli@gmail.com
#> - staging data transfer at url endpoint or request id:
#>   https://api.ecmwf.int/v1/datasets/interim/requests/5d72a1f713e01cd44c6f4858
#> 
#> - timeout set to 1.0 hours
#> - polling server for a data transfer
#> Downloading file
#> |=================================================================================================| 100%
#> - file not copied and removed (path == tempdir())
#> - request purged from queue!
```


This uses the somewhat hacky function `retrieve_header`. If curl or httr decide to implement the `--head` argument, then it could be changed to a cleaner solution. 