### PR TITLE
Fix comma problem in Copernicus parser

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -84,6 +84,9 @@ python_to_list <- function(python_text) {
     c_brackets <- substr(c_brackets, 1, nchar(c_brackets)-1)
   }
 
+  # Remove trailing commas (",]")
+  c_brackets <- gsub(",]", "]", c_brackets)
+
   # read in data as list
   c_list <- jsonlite::fromJSON(paste0("{",c_brackets,"}"))
 


### PR DESCRIPTION
I've got this request code from Copernicus and the "Python to list" addin couldn't parse it because of the trailing commas.

```
c.retrieve(
  'reanalysis-era5-pressure-levels-monthly-means',
  {
    'format': 'netcdf',
    'product_type': 'monthly_averaged_reanalysis',
    'variable': [
      'u_component_of_wind', 'v_component_of_wind', 'vertical_velocity',
      'vorticity',
      ],
    'pressure_level': [
      '1', '2', '3',
      '5', '7', '10',
      '20', '30', '50',
      '70', '100', '125',
      '150', '175', '200',
      '225', '250', '300',
      '350', '400', '450',
      '500', '550', '600',
      '650', '700', '750',
      '775', '800', '825',
      '850', '875', '900',
      '925', '950', '975',
      '1000',
      ],
    'year': [
      '1979', '1980', '1981',
      '1982', '1983', '1984',
      '1985', '1986', '1987',
      '1988', '1989', '1990',
      '1991', '1992', '1993',
      '1994', '1995', '1996',
      '1997', '1998', '1999',
      '2000', '2001', '2002',
      '2003', '2004', '2005',
      '2006', '2007', '2008',
      '2009', '2010', '2011',
      '2012', '2013', '2014',
      '2015', '2016', '2017',
      '2018', '2019',
      ],
    'month': [
      '01', '02', '03',
      '04', '05', '06',
      '07', '08', '09',
      '10', '11', '12',
      ],
    'time': '00:00',
  },
  'download.nc')
```

I added a regex to remove these cases and now it works. 