### PR TITLE
Adds progress bar to CDS dowload

### DIFF
--- a/R/wf_transfer.R
+++ b/R/wf_transfer.R
@@ -156,7 +156,8 @@ wf_transfer <- function(
 
       # download file
       httr::GET(ct$location,
-                  httr::write_disk(tmp_file, overwrite = TRUE))
+                httr::write_disk(tmp_file, overwrite = TRUE),
+                httr::progress())
 
       # return exit statement
       ct$code <- 302


### PR DESCRIPTION
I realised that webapi downloads were printing out a progress bar but CDS downlaods didn't . This fixes that problem. 