### PR TITLE
Removes trailing comma

### DIFF
--- a/R/wf_request.R
+++ b/R/wf_request.R
@@ -111,7 +111,7 @@ wf_request <- function(
   # checks user login, the request layout and
   # returns the service to use if successful
   wf_check <- lapply(user, function(u) try(wf_check_request(u, request), silent = TRUE))
-  correct <- which(!vapply(wf_check, inherits, TRUE, "try-error",))
+  correct <- which(!vapply(wf_check, inherits, TRUE, "try-error"))
   wf_check <- wf_check[[correct]]
   user <- user[correct]
 


### PR DESCRIPTION
Fixes #49 . The issue was here: https://github.com/khufkens/ecmwfr/blob/7ed5c96d969bf5b733671be8313350d03aa54de4/R/wf_request.R#L114

The trailing comma throws an error in R 3.4.4 but it works fine in R 3.6. I removed it and now it works :D